### PR TITLE
displayAjaxCDNUniqueFilename returns 404 is status=draft

### DIFF
--- a/www/js/s3upload.js
+++ b/www/js/s3upload.js
@@ -197,10 +197,6 @@ function s3upload($, plupload, options) {
 	}
 
 	function onPluploadBeforeUpload(uploader, file) {
-		// AJM 
-		// var ajaxurl = options.fc.webroot + "&type=" + options.fc.typename + "&objectid=" + options.fc.objectid
-		//			+ "&property=" + options.fc.property + "&view=displayAjaxCDNUniqueFilename";
-		
 		var ajaxurl = options.fc.webroot  +  "&view=displayAjaxCDNUniqueFilename";
 
 		// get unique filename from the server

--- a/www/js/s3upload.js
+++ b/www/js/s3upload.js
@@ -197,8 +197,11 @@ function s3upload($, plupload, options) {
 	}
 
 	function onPluploadBeforeUpload(uploader, file) {
-		var ajaxurl = options.fc.webroot + "&type=" + options.fc.typename + "&objectid=" + options.fc.objectid
-					+ "&property=" + options.fc.property + "&view=displayAjaxCDNUniqueFilename";
+		// AJM 
+		// var ajaxurl = options.fc.webroot + "&type=" + options.fc.typename + "&objectid=" + options.fc.objectid
+		//			+ "&property=" + options.fc.property + "&view=displayAjaxCDNUniqueFilename";
+		
+		var ajaxurl = options.fc.webroot  +  "&view=displayAjaxCDNUniqueFilename";
 
 		// get unique filename from the server
 		$.ajax({


### PR DESCRIPTION
calls to displayAjaxCDNUniqueFilename currently create an object, and if that object has a status and it is set to default, a 404 is returned

`/index.cfm?ajaxmode=1&type=mcClassified&objectid=9EA316A0-B46E-11E7-8ED40242AC110004&property=aImages&view=displayAjaxCDNUniqueFilename`

This patch removes type, objectid & property from the URL which do not appear to be used
`/index.cfm?ajaxmode=1&view=displayAjaxCDNUniqueFilename`

This is inline with how displayAjaxSaveFile is called
`/index.cfm?ajaxmode=1&type=mcClassifiedImage&view=displayAjaxSaveFile`